### PR TITLE
install eden/common/utils/FileOffset.h

### DIFF
--- a/eden/common/utils/CMakeLists.txt
+++ b/eden/common/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ set(utils_headers
   ${CMAKE_CURRENT_SOURCE_DIR}/ProcessName.h
   ${CMAKE_CURRENT_SOURCE_DIR}/ProcessNameCache.h
   ${CMAKE_CURRENT_SOURCE_DIR}/OptionSet.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/FileOffset.h
   ${CMAKE_CURRENT_SOURCE_DIR}/FileUtils.h
 )
 


### PR DESCRIPTION
install eden/common/utils/FileOffset.h

edenfs uses this header but it was missing from the cmake install of edencommon

Test Plan:

./build/fbcode_builder/getdeps.py build --allow-system-packages --src-dir=. edencommon

before, header not installed

after, the header is installed
