### PR TITLE
Fix linker failure on macOS

### DIFF
--- a/eden/common/os/CMakeLists.txt
+++ b/eden/common/os/CMakeLists.txt
@@ -12,8 +12,18 @@ add_library(edencommon_os
   ProcessId.cpp
 )
 
-target_link_libraries(edencommon_os
+set(os_libs
   fmt::fmt
+)
+
+if (NOT WIN32)
+  list(APPEND os_libs
+    Folly::folly
+  )
+endif()
+
+target_link_libraries(edencommon_os
+  ${os_libs}
 )
 
 target_include_directories(edencommon_os PUBLIC


### PR DESCRIPTION
edencommon_os needs to link to folly on macOS.[^1]

Without this, building on macOS fails[^2] with

    Undefined symbols for architecture arm64:
      "folly::get_cached_pid()", referenced from:
          facebook::eden::ProcessId::current() in ProcessId.cpp.o
    ld: symbol(s) not found for architecture arm64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    make[2]: *** [eden/common/os/libedencommon_os.dylib] Error 1
    make[1]: *** [eden/common/os/CMakeFiles/edencommon_os.dir/all] Error 2

[^1]: https://github.com/facebookexperimental/edencommon/blob/518f2264f4d9feda635980d1b11242fda3767fd0/eden/common/os/ProcessId.cpp#L49-L60
[^2]: https://github.com/Homebrew/homebrew-core/actions/runs/5642189825/job/15281692111#step:3:219