### PR TITLE
Wrap/replace unformattable types

### DIFF
--- a/eden/common/utils/PathFuncs.cpp
+++ b/eden/common/utils/PathFuncs.cpp
@@ -215,7 +215,7 @@ folly::Expected<RelativePath, int> joinAndNormalize(
   }
   const std::string joined = base.value().empty() ? std::string{path}
       : path.empty()                              ? std::string{base.value()}
-                     : fmt::format("{}{}{}", base, kDirSeparator, path);
+                     : fmt::format("{}{}{}", base, kDirSeparatorStr, path);
   const CanonicalData cdata{canonicalPathData(joined)};
   const auto& parts{cdata.components};
   XDCHECK(!cdata.isAbsolute);

--- a/eden/common/utils/PathFuncs.h
+++ b/eden/common/utils/PathFuncs.h
@@ -1510,7 +1510,7 @@ struct AbsolutePathSanityCheck {
     if (!val.starts_with(detail::kRootStr)) {
       throw_<std::domain_error>(
           "attempt to construct an AbsolutePath from a non-absolute string: \"",
-          val,
+          std::string_view(val),
           "\"");
     }
     size_t offset = detail::kRootStr.size();
@@ -1518,7 +1518,7 @@ struct AbsolutePathSanityCheck {
     if (val.size() > 1 && val.ends_with(kDirSeparator)) {
       // We do allow "/" though
       throw_<std::domain_error>(
-          "AbsolutePath must not end with a slash: ", val);
+          "AbsolutePath must not end with a slash: ", std::string_view(val));
     }
 
     if (val.size() > offset) {


### PR DESCRIPTION
Hey, I maintain the [Arch User Repository (AUR) package for edencommon](https://aur.archlinux.org/packages/edencommon). The latest release (`v2024.03.04.00`) fails to compile with the following error:

```
-- Found gflags from package config /usr/lib/cmake/gflags/gflags-config.cmake
-- Found folly: /usr
-- Found gmock via config, defines=, include=/usr/include, libs=GTest::gmock_main;GTest::gmock;GTest::gtest
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/build
[  5%] Built target edencommon_os
[  7%] Building CXX object eden/common/utils/CMakeFiles/edencommon_utils.dir/FileUtils.cpp.o
[ 10%] Building CXX object eden/common/utils/CMakeFiles/edencommon_utils.dir/PathFuncs.cpp.o
[ 15%] Built target os_test
In file included from /usr/include/fmt/format.h:49,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:13,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.cpp:8:
/usr/include/fmt/core.h: In instantiation of ‘constexpr fmt::v10::detail::value<Context> fmt::v10::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; T = facebook::eden::<unnamed enum>; typename std::enable_if<PACKED, int>::type <anonymous> = 0]’:
/usr/include/fmt/core.h:1842:51:   required from ‘constexpr fmt::v10::format_arg_store<Context, Args>::format_arg_store(T& ...) [with T = {facebook::eden::detail::RelativePathBase<std::basic_string_view<char, std::char_traits<char> > >, facebook::eden::<unnamed enum>, facebook::eden::string_view}; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; Args = {facebook::eden::detail::RelativePathBase<std::basic_string_view<char, std::char_traits<char> > >, facebook::eden::<unnamed enum>, facebook::eden::string_view}]’
/usr/include/fmt/core.h:1860:18:   required from ‘constexpr fmt::v10::format_arg_store<Context, typename std::remove_cv<typename std::remove_reference<T>::type>::type ...> fmt::v10::make_format_args(T& ...) [with Context = basic_format_context<appender, char>; T = {facebook::eden::detail::RelativePathBase<std::basic_string_view<char, std::char_traits<char> > >, facebook::eden::<unnamed enum>, facebook::eden::string_view}]’
/usr/include/fmt/core.h:2835:44:   required from ‘std::string fmt::v10::format(format_string<T ...>, T&& ...) [with T = {facebook::eden::detail::RelativePathBase<std::basic_string_view<char, std::char_traits<char> > >&, facebook::eden::<unnamed enum>, facebook::eden::string_view&}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, facebook::eden::detail::RelativePathBase<std::basic_string_view<char, std::char_traits<char> > >&, facebook::eden::<unnamed enum>, facebook::eden::string_view&>]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.cpp:218:35:   required from here
/usr/include/fmt/core.h:1600:63: error: ‘fmt::v10::detail::type_is_unformattable_for<facebook::eden::<unnamed enum>, char> _’ has incomplete type
 1600 |     type_is_unformattable_for<T, typename Context::char_type> _;
      |                                                               ^
/usr/include/fmt/core.h:1604:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
 1604 |       formattable,
      |       ^~~~~~~~~~~
/usr/include/fmt/core.h:1604:7: note: ‘formattable’ evaluates to false
In file included from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/Throw.h:10,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:27:
/usr/include/fmt/ranges.h: In instantiation of ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 2; Char = char; T = {const char*, facebook::eden::string_view, const char*}; typename FormatContext::iterator = fmt::v10::appender]’:
/usr/include/fmt/ranges.h:648:23:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 3; Char = char; T = {const char*, facebook::eden::string_view, const char*}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/ranges.h:602:21:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; Char = char; T = {const char*, facebook::eden::string_view, const char*}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/format.h:3761:26:   required from ‘constexpr fmt::v10::enable_if_t<(fmt::v10::detail::type_constant<decltype (fmt::v10::detail::arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == fmt::v10::detail::type::custom_type), OutputIt> fmt::v10::detail::write(OutputIt, const T&) [with Char = char; OutputIt = fmt::v10::appender; T = fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view, const char*>; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; fmt::v10::enable_if_t<(type_constant<decltype (arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == type::custom_type), OutputIt> = fmt::v10::appender; decltype (arg_mapper<Context>().map(declval<const T&>())) = const fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view, const char*>&; typename Context::char_type = char]’
/usr/include/fmt/format.h:4320:22:   required from ‘std::string fmt::v10::to_string(const T&) [with T = tuple_join_view<char, const char*, facebook::eden::string_view, const char*>; typename std::enable_if<((! std::is_integral<_Tp>::value) && (! detail::has_format_as<T>::value)), int>::type <anonymous> = 0; std::string = std::__cxx11::basic_string<char>]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/Throw.h:46:40:   required from ‘void facebook::eden::throw_(T&& ...) [with E = std::domain_error; T = {const char (&)[67], string_view&, const char (&)[2]}]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:1511:32:   required from here
/usr/include/fmt/ranges.h:644:27: error: no matching function for call to ‘fmt::v10::formatter<facebook::eden::string_view>::format(std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view, const char*> >&, fmt::v10::basic_format_context<fmt::v10::appender, char>&) const’
  643 |     auto out = std::get<sizeof...(T) - N>(formatters_)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  644 |                    .format(std::get<sizeof...(T) - N>(value.tuple), ctx);
      |                    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/core.h:2759:22: note: candidate: ‘template<class FormatContext> constexpr decltype (ctx.out()) fmt::v10::formatter<T, Char, typename std::enable_if<(fmt::v10::detail::type_constant<T, Char>::value != fmt::v10::detail::type::custom_type), void>::type>::format(const T&, FormatContext&) const [with T = fmt::v10::basic_string_view<char>; Char = char]’
 2759 |   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
      |                      ^~~~~~
/usr/include/fmt/core.h:2759:22: note:   template argument deduction/substitution failed:
/usr/include/fmt/ranges.h:644:27: note:   cannot convert ‘std::get<1, const char*, facebook::eden::string_view, const char*>((* & value.fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view, const char*>::tuple))’ (type ‘std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view, const char*> >’ {aka ‘const facebook::eden::string_view’}) to type ‘const fmt::v10::basic_string_view<char>&’
  643 |     auto out = std::get<sizeof...(T) - N>(formatters_)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  644 |                    .format(std::get<sizeof...(T) - N>(value.tuple), ctx);
      |                    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/ranges.h: In instantiation of ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 1; Char = char; T = {const char*, facebook::eden::string_view}; typename FormatContext::iterator = fmt::v10::appender]’:
/usr/include/fmt/ranges.h:648:23:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 2; Char = char; T = {const char*, facebook::eden::string_view}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/ranges.h:602:21:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; Char = char; T = {const char*, facebook::eden::string_view}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/format.h:3761:26:   required from ‘constexpr fmt::v10::enable_if_t<(fmt::v10::detail::type_constant<decltype (fmt::v10::detail::arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == fmt::v10::detail::type::custom_type), OutputIt> fmt::v10::detail::write(OutputIt, const T&) [with Char = char; OutputIt = fmt::v10::appender; T = fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view>; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; fmt::v10::enable_if_t<(type_constant<decltype (arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == type::custom_type), OutputIt> = fmt::v10::appender; decltype (arg_mapper<Context>().map(declval<const T&>())) = const fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view>&; typename Context::char_type = char]’
/usr/include/fmt/format.h:4320:22:   required from ‘std::string fmt::v10::to_string(const T&) [with T = tuple_join_view<char, const char*, facebook::eden::string_view>; typename std::enable_if<((! std::is_integral<_Tp>::value) && (! detail::has_format_as<T>::value)), int>::type <anonymous> = 0; std::string = std::__cxx11::basic_string<char>]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/Throw.h:46:40:   required from ‘void facebook::eden::throw_(T&& ...) [with E = std::domain_error; T = {const char (&)[41], string_view&}]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:1520:32:   required from here
/usr/include/fmt/ranges.h:644:27: error: no matching function for call to ‘fmt::v10::formatter<facebook::eden::string_view>::format(std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view> >&, fmt::v10::basic_format_context<fmt::v10::appender, char>&) const’
/usr/include/fmt/core.h:2759:22: note: candidate: ‘template<class FormatContext> constexpr decltype (ctx.out()) fmt::v10::formatter<T, Char, typename std::enable_if<(fmt::v10::detail::type_constant<T, Char>::value != fmt::v10::detail::type::custom_type), void>::type>::format(const T&, FormatContext&) const [with T = fmt::v10::basic_string_view<char>; Char = char]’
 2759 |   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
      |                      ^~~~~~
/usr/include/fmt/core.h:2759:22: note:   template argument deduction/substitution failed:
/usr/include/fmt/ranges.h:644:27: note:   cannot convert ‘std::get<1, const char*, facebook::eden::string_view>((* & value.fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view>::tuple))’ (type ‘std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view> >’ {aka ‘const facebook::eden::string_view’}) to type ‘const fmt::v10::basic_string_view<char>&’
  643 |     auto out = std::get<sizeof...(T) - N>(formatters_)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  644 |                    .format(std::get<sizeof...(T) - N>(value.tuple), ctx);
      |                    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/Throw.h:10,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:27,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/FileUtils.h:17,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/FileUtils.cpp:8:
/usr/include/fmt/ranges.h: In instantiation of ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 2; Char = char; T = {const char*, facebook::eden::string_view, const char*}; typename FormatContext::iterator = fmt::v10::appender]’:
/usr/include/fmt/ranges.h:648:23:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 3; Char = char; T = {const char*, facebook::eden::string_view, const char*}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/ranges.h:602:21:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; Char = char; T = {const char*, facebook::eden::string_view, const char*}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/format.h:3761:26:   required from ‘constexpr fmt::v10::enable_if_t<(fmt::v10::detail::type_constant<decltype (fmt::v10::detail::arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == fmt::v10::detail::type::custom_type), OutputIt> fmt::v10::detail::write(OutputIt, const T&) [with Char = char; OutputIt = fmt::v10::appender; T = fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view, const char*>; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; fmt::v10::enable_if_t<(type_constant<decltype (arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == type::custom_type), OutputIt> = fmt::v10::appender; decltype (arg_mapper<Context>().map(declval<const T&>())) = const fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view, const char*>&; typename Context::char_type = char]’
/usr/include/fmt/format.h:4320:22:   required from ‘std::string fmt::v10::to_string(const T&) [with T = tuple_join_view<char, const char*, facebook::eden::string_view, const char*>; typename std::enable_if<((! std::is_integral<_Tp>::value) && (! detail::has_format_as<T>::value)), int>::type <anonymous> = 0; std::string = std::__cxx11::basic_string<char>]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/Throw.h:46:40:   required from ‘void facebook::eden::throw_(T&& ...) [with E = std::domain_error; T = {const char (&)[67], string_view&, const char (&)[2]}]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:1511:32:   required from here
/usr/include/fmt/ranges.h:644:27: error: no matching function for call to ‘fmt::v10::formatter<facebook::eden::string_view>::format(std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view, const char*> >&, fmt::v10::basic_format_context<fmt::v10::appender, char>&) const’
  643 |     auto out = std::get<sizeof...(T) - N>(formatters_)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  644 |                    .format(std::get<sizeof...(T) - N>(value.tuple), ctx);
      |                    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/fmt/format.h:49,
                 from /usr/include/folly/Range.h:63,
                 from /tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/FileUtils.h:10:
/usr/include/fmt/core.h:2759:22: note: candidate: ‘template<class FormatContext> constexpr decltype (ctx.out()) fmt::v10::formatter<T, Char, typename std::enable_if<(fmt::v10::detail::type_constant<T, Char>::value != fmt::v10::detail::type::custom_type), void>::type>::format(const T&, FormatContext&) const [with T = fmt::v10::basic_string_view<char>; Char = char]’
 2759 |   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
      |                      ^~~~~~
/usr/include/fmt/core.h:2759:22: note:   template argument deduction/substitution failed:
/usr/include/fmt/ranges.h:644:27: note:   cannot convert ‘std::get<1, const char*, facebook::eden::string_view, const char*>((* & value.fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view, const char*>::tuple))’ (type ‘std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view, const char*> >’ {aka ‘const facebook::eden::string_view’}) to type ‘const fmt::v10::basic_string_view<char>&’
  643 |     auto out = std::get<sizeof...(T) - N>(formatters_)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  644 |                    .format(std::get<sizeof...(T) - N>(value.tuple), ctx);
      |                    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/ranges.h: In instantiation of ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 1; Char = char; T = {const char*, facebook::eden::string_view}; typename FormatContext::iterator = fmt::v10::appender]’:
/usr/include/fmt/ranges.h:648:23:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::do_format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&, std::integral_constant<long unsigned int, N>) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; long unsigned int N = 2; Char = char; T = {const char*, facebook::eden::string_view}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/ranges.h:602:21:   required from ‘typename FormatContext::iterator fmt::v10::formatter<fmt::v10::tuple_join_view<Char, T ...>, Char>::format(const fmt::v10::tuple_join_view<Char, T ...>&, FormatContext&) const [with FormatContext = fmt::v10::basic_format_context<fmt::v10::appender, char>; Char = char; T = {const char*, facebook::eden::string_view}; typename FormatContext::iterator = fmt::v10::appender]’
/usr/include/fmt/format.h:3761:26:   required from ‘constexpr fmt::v10::enable_if_t<(fmt::v10::detail::type_constant<decltype (fmt::v10::detail::arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == fmt::v10::detail::type::custom_type), OutputIt> fmt::v10::detail::write(OutputIt, const T&) [with Char = char; OutputIt = fmt::v10::appender; T = fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view>; Context = fmt::v10::basic_format_context<fmt::v10::appender, char>; fmt::v10::enable_if_t<(type_constant<decltype (arg_mapper<Context>().map(declval<const T&>())), typename Context::char_type>::value == type::custom_type), OutputIt> = fmt::v10::appender; decltype (arg_mapper<Context>().map(declval<const T&>())) = const fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view>&; typename Context::char_type = char]’
/usr/include/fmt/format.h:4320:22:   required from ‘std::string fmt::v10::to_string(const T&) [with T = tuple_join_view<char, const char*, facebook::eden::string_view>; typename std::enable_if<((! std::is_integral<_Tp>::value) && (! detail::has_format_as<T>::value)), int>::type <anonymous> = 0; std::string = std::__cxx11::basic_string<char>]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/Throw.h:46:40:   required from ‘void facebook::eden::throw_(T&& ...) [with E = std::domain_error; T = {const char (&)[41], string_view&}]’
/tmp/makepkg/edencommon/src/edencommon-2024.03.04.00/eden/common/utils/PathFuncs.h:1520:32:   required from here
/usr/include/fmt/ranges.h:644:27: error: no matching function for call to ‘fmt::v10::formatter<facebook::eden::string_view>::format(std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view> >&, fmt::v10::basic_format_context<fmt::v10::appender, char>&) const’
/usr/include/fmt/core.h:2759:22: note: candidate: ‘template<class FormatContext> constexpr decltype (ctx.out()) fmt::v10::formatter<T, Char, typename std::enable_if<(fmt::v10::detail::type_constant<T, Char>::value != fmt::v10::detail::type::custom_type), void>::type>::format(const T&, FormatContext&) const [with T = fmt::v10::basic_string_view<char>; Char = char]’
 2759 |   FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const
      |                      ^~~~~~
/usr/include/fmt/core.h:2759:22: note:   template argument deduction/substitution failed:
/usr/include/fmt/ranges.h:644:27: note:   cannot convert ‘std::get<1, const char*, facebook::eden::string_view>((* & value.fmt::v10::tuple_join_view<char, const char*, facebook::eden::string_view>::tuple))’ (type ‘std::__tuple_element_t<1, std::tuple<const char*, facebook::eden::string_view> >’ {aka ‘const facebook::eden::string_view’}) to type ‘const fmt::v10::basic_string_view<char>&’
  643 |     auto out = std::get<sizeof...(T) - N>(formatters_)
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  644 |                    .format(std::get<sizeof...(T) - N>(value.tuple), ctx);
      |                    ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [eden/common/utils/CMakeFiles/edencommon_utils.dir/build.make:76: eden/common/utils/CMakeFiles/edencommon_utils.dir/FileUtils.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [eden/common/utils/CMakeFiles/edencommon_utils.dir/build.make:118: eden/common/utils/CMakeFiles/edencommon_utils.dir/PathFuncs.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:308: eden/common/utils/CMakeFiles/edencommon_utils.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

I think the cause is related to some files added in 0923e41, specifically `eden/common/utils/PathFuncs.{cpp,h}`, not being compatible with fmt v10.2.0. With the changes suggested in this PR, the package builds successfully.