### PR TITLE
Allow building shared libraries when requested

### DIFF
--- a/eden/common/testharness/CMakeLists.txt
+++ b/eden/common/testharness/CMakeLists.txt
@@ -8,7 +8,6 @@ file(GLOB testharness_sources CONFIGURE_DEPENDS *.cpp)
 
 add_library(
   edencommon_testharness
-  STATIC
   ${testharness_headers}
   ${testharness_sources}
 )

--- a/eden/common/utils/CMakeLists.txt
+++ b/eden/common/utils/CMakeLists.txt
@@ -26,7 +26,6 @@ endif()
 
 add_library(
   edencommon_utils
-  STATIC
     ${utils_headers}
     ${utils_sources})
 


### PR DESCRIPTION
CMake builds static libraries by default unless requested otherwise with
`BUILD_SHARED_LIBS`. However, this is made impossible when you pass
`STATIC` to `add_library`.

Passing `STATIC` isn't really necessary, and can be a hinderance for
downstream users. See, for example, facebook/mvfst#302.
