### PR TITLE
Migrate OSS project to handle protocol split

### DIFF
--- a/build/fbcode_builder/CMake/FBThriftCppLibrary.cmake
+++ b/build/fbcode_builder/CMake/FBThriftCppLibrary.cmake
@@ -69,6 +69,8 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
     "${output_dir}/gen-cpp2/${base}_data.h"
     "${output_dir}/gen-cpp2/${base}_data.cpp"
     "${output_dir}/gen-cpp2/${base}_types.cpp"
+    "${output_dir}/gen-cpp2/${base}_types_compact.cpp"
+    "${output_dir}/gen-cpp2/${base}_types_binary.cpp"
     "${output_dir}/gen-cpp2/${base}_metadata.cpp"
   )
   foreach(service IN LISTS ARG_SERVICES)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/CacheLib/pull/386

X-link: https://github.com/facebook/fb303/pull/67

fbthrift has moved compact/binary protocol instantiation outside _types.cpp (to _types_compact.cpp and _types_binary.cpp). We need to add these two files to the build system.

Differential Revision: D74687663


