### PR TITLE
Include missing headers in SessionInfo.h

### DIFF
--- a/eden/common/telemetry/SessionInfo.h
+++ b/eden/common/telemetry/SessionInfo.h
@@ -9,6 +9,8 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
+#include <variant>
 
 #include "eden/common/utils/UserInfo.h"
 


### PR DESCRIPTION
Seeing the following error when building watchman OSS with GCC both in CI and locally:

```
2025-05-30T17:13:46.0751285Z In file included from /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/StructuredLogger.h:14,
2025-05-30T17:13:46.0753774Z                  from /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/ScubaStructuredLogger.h:12,
2025-05-30T17:13:46.0755621Z                  from /home/runner/work/watchman/watchman/watchman/telemetry/WatchmanStructuredLogger.h:11,
2025-05-30T17:13:46.0756771Z                  from /home/runner/work/watchman/watchman/watchman/SanityCheck.cpp:17:
2025-05-30T17:13:46.0759407Z /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/SessionInfo.h:26:40: error: ‘variant’ is not a member of ‘std’
2025-05-30T17:13:46.0761424Z    26 |   std::unordered_map<std::string, std::variant<std::string, uint64_t>> fbInfo;
2025-05-30T17:13:46.0762244Z       |                                        ^~~~~~~
2025-05-30T17:13:46.0764788Z /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/SessionInfo.h:14:1: note: ‘std::variant’ is defined in header ‘<variant>’; did you forget to ‘#include <variant>’?
2025-05-30T17:13:46.0766824Z    13 | #include "eden/common/utils/UserInfo.h"
2025-05-30T17:13:46.0767466Z   +++ |+#include <variant>
2025-05-30T17:13:47.1569706Z Command '['/usr/local/bin/cmake', '--build', '/tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/build/watchman', '--target', 'install', '--config', 'RelWithDebInfo', '-j', '4']' returned non-zero exit status 1.
2025-05-30T17:13:47.1571863Z !! Failed
2025-05-30T17:13:47.1572149Z    14 |
2025-05-30T17:13:47.1573031Z /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/SessionInfo.h:26:61: error: template argument 2 is invalid
2025-05-30T17:13:47.1574161Z    26 |   std::unordered_map<std::string, std::variant<std::string, uint64_t>> fbInfo;
2025-05-30T17:13:47.1574631Z       |                                                             ^~~~~~~~
2025-05-30T17:13:47.1575590Z /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/SessionInfo.h:26:61: error: template argument 5 is invalid
2025-05-30T17:13:47.1577640Z /tmp/fbcode_builder_getdeps-ZhomeZrunnerZworkZwatchmanZwatchmanZbuildZfbcode_builder/installed/edencommon/include/eden/common/telemetry/SessionInfo.h:26:69: error: expected unqualified-id before ‘>’ token
2025-05-30T17:13:47.1578729Z    26 |   std::unordered_map<std::string, std::variant<std::string, uint64_t>> fbInfo;
2025-05-30T17:13:47.1579434Z       |
```